### PR TITLE
Fix release CI from failing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ ci: lint build-docs build-js build-python
 
 .PHONY: set-release-version
 set-release-version:
-	yarn version --new-version $$(poetry run python bin/get_release_version.py)
+	npm version --new-version $$(poetry run python bin/get_release_version.py) --no-git-tag-version
 	poetry version $$(poetry run python bin/get_release_version.py)
 
 .PHONY: build-js


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please also read our [contributor guidelines](https://groundwork.commonknowledge.coop/contributing) -->

## Description

Prevents npm from attempting to create a tag on release


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it relates an open issue, please link to the issue here. -->

Npm releases were failing from github CI release triggers because it attempts to create a tag that already exists – it is the creation of the tag in the github UI that triggers the action.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Tooling & CI

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have documented all new methods using google docstring format.
- [x] I have added type annotations to any public API methods.
- [x] I have updated any relevant high-level documentation.
- [x] I have added a usage example to the example app if relevant.
- [x] I have written tests covering all new changes.
